### PR TITLE
Fix CURLFile namespace.

### DIFF
--- a/src/BoxAPI.php
+++ b/src/BoxAPI.php
@@ -547,7 +547,7 @@ class BoxAPI {
 		if ( !isset( $name ) || empty ($name) ) {
 			$name = basename( $filename );
 		}
-		$file   = new CURLFile( $filename );
+		$file   = new \CURLFile( $filename );
 		$params = [
 			'file'         => $file,
 			'name'         => $name,


### PR DESCRIPTION
Using BoxPHPAPI on PHP 7.2, it couldn't find CURLFile. For want of a backslash...