### PR TITLE
Copy a large file to the local fs

### DIFF
--- a/src/BoxAPI.php
+++ b/src/BoxAPI.php
@@ -26,6 +26,42 @@ namespace HobieCat\PHPBoxAPI;
 
 use \Firebase\JWT\JWT;
 
+if (!function_exists('http_parse_headers')) {
+	function http_parse_headers($raw_headers) {
+		$headers = array();
+		$key = '';
+
+		foreach(explode("\n", $raw_headers) as $i => $h) {
+			$h = explode(':', $h, 2);
+
+			if (isset($h[1])) {
+				if (!isset($headers[$h[0]])) {
+					$headers[$h[0]] = trim($h[1]);
+				}
+				elseif (is_array($headers[$h[0]])) {
+					$headers[$h[0]] = array_merge($headers[$h[0]], array(trim($h[1])));
+				}
+				else {
+					$headers[$h[0]] = array_merge(array($headers[$h[0]]), array(trim($h[1])));
+				}
+
+				$key = $h[0];
+			}
+			else {
+				if (substr($h[0], 0, 1) == "\t") {
+					$headers[$key] .= "\r\n\t" . trim($h[0]);
+				}
+				elseif (!$key) {
+					$headers[0] = trim($h[0]);
+					trim($h[0]);
+				}
+			}
+		}
+
+		return $headers;
+	}
+}
+
 class BoxAPI {
 
 	public $clientId 		 = '';
@@ -429,6 +465,23 @@ class BoxAPI {
 
         return json_decode( $this->post( $url, json_encode( $params ),[ "BoxApi: shared_link=".$link ] ), true );
     }
+
+	/**
+	 * Copy a file to the local file system.
+	 *
+	 * This function uses a limited amount of memory and is able to copy large files.
+	 *
+	 * @param $file
+	 * @param $destination
+	 *
+	 * @return mixed
+	 */
+	public function copyToLocal( $file, $destination ) {
+		$url = $this->getFile( $file );
+
+		// copy() does not allocate the whole content in memory.
+		return copy( $url, $destination );
+	}
 
 	/**
 	 * Get a file.


### PR DESCRIPTION
Currently to copy a file you need to call `getFileContent()` and copy the content. This means keeping the content of the whole file in memory, which does not scale with large files.

This PR adds a method to copy a file to the local fs without allocating the whole content in memory.

It also adds a fallback for http_parse_headers(), in case pecl_http is not installed.