### PR TITLE
'name' is not used, unless the parameters are JSON-encoded

### DIFF
--- a/src/BoxAPI.php
+++ b/src/BoxAPI.php
@@ -548,12 +548,15 @@ class BoxAPI {
 			$name = basename( $filename );
 		}
 		$file   = new CURLFile( $filename );
-		$params = [
-			'file'         => $file,
-			'name'         => $name,
-			'parent_id'    => $parent_id,
-			'access_token' => $this->accessToken
-		];
+    $attributes = json_encode([
+      'name' => $name,
+      'parent' => ['id' => $parent_id],
+    ]);
+    $params = [
+      'attributes' => $attributes,
+      'file'         => $file,
+      'access_token' => $this->accessToken
+    ];
 
 		return json_decode( $this->post( $url, $params ), true );
 	}


### PR DESCRIPTION
With the simple array of parameters currently used in putFile(), the upload succeeds but 'name' is ignored - the Box file ends up named for the basename of the source file instead. Passing 'attributes' with the JSON structure documented under Upload File at https://developer.box.com/reference does work, however.