### PR TITLE
Add possibility to handle erros through exceptions

### DIFF
--- a/src/BoxRequestException.php
+++ b/src/BoxRequestException.php
@@ -1,0 +1,95 @@
+<?php
+
+namespace HobieCat\PHPBoxAPI;
+
+class BoxRequestException extends \Exception {
+
+	/**
+	 * @var string
+	 */
+	private $responseData;
+
+	/**
+	 * @var string
+	 */
+	private $curlError;
+
+	/**
+	 * @var int
+	 */
+	private $curlErrorCode;
+
+	/**
+	 * @var string
+	 */
+	private $requestMethod;
+
+	/**
+	 * @var string
+	 */
+	private $requestUrl;
+
+	/**
+	 * @var array
+	 */
+	private $requestHeaders;
+
+	/**
+	 * BoxRequestException constructor.
+	 * @param string $message
+	 * @param int $code
+	 * @param Throwable|NULL $previous
+	 */
+	public function __construct($message, $code, $responseData, $curlError = '', $curlErrorCode = 0, $requestMethod = '', $requestUrl = '', $requestHeaders = [], Throwable $previous = null) {
+		parent::__construct($message, $code, $previous);
+		$this->responseData = $responseData;
+		$this->curlError = $curlError;
+		$this->curlErrorCode = $curlErrorCode;
+		$this->requestMethod = $requestMethod;
+		$this->requestUrl = $requestUrl;
+		$this->requestHeaders = $requestHeaders;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getReponseData() {
+		return $this->responseData;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getCurlError() {
+		return $this->curlError;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getCurlErrorCode() {
+		return $this->curlErrorCode;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRequestMethod() {
+		$this->requestMethod;
+	}
+
+	/**
+	 * @return string
+	 */
+	public function getRequestUrl() {
+		$this->requestUrl;
+	}
+
+	/**
+	 * @return int
+	 */
+	public function getRequestHeaders() {
+		$this->requestHeaders;
+	}
+
+}


### PR DESCRIPTION
This pull request depends on #9.

We've run into challenges that originated from the fact that the library doesn't really handle exceptions. To solve that problem we added possibility to handle errors through exceptions being thrown. In order to avoid backward compatibility changes we made that opt-in. 

Besides that this pull also implements support for connection errors (cURL returns status code 0 - https://stackoverflow.com/questions/10227879/php-curl-http-code-return-0) and fixed few indentation inconsistencies.  